### PR TITLE
Fix for https://github.com/contino/terraform-learn/issues/5

### DIFF
--- a/gcp/modules/compute/nodes/demo_node/demo_node.tf
+++ b/gcp/modules/compute/nodes/demo_node/demo_node.tf
@@ -7,10 +7,11 @@ resource "google_compute_instance" "demo-node" {
   machine_type = "${var.machine_type}"
   zone         = "${var.zone}"
   count        = "${var.count}"
-
-  # machine image to use
-  disk {
-    image = "${var.image}"
+  
+  boot_disk {
+    initialize_params {
+      image = "${var.image}"
+    }
   }
 
   # network config


### PR DESCRIPTION
cd terraform-learn/gcp/environments/test/compute
terraform plan -var-file=./terraform.tfvars
Gets you this error

Error: module.demo-node.google_compute_instance.demo-node: "boot_disk": required field is not set
Minor update to will fix this gcp/modules/compute/nodes/demo_node/demo_node.tf

  boot_disk {
    initialize_params {
      image = "${var.image}"
    }
  }